### PR TITLE
Make main thread actions sequential

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -101,11 +101,8 @@ async fn analyze_input(
                 let result = delete_notification(id, hash_map.clone(), glue.clone()).await;
 
                 match result {
-                    Ok(_) => println!(
-                        "{}",
-                        format!("Notification (id: {}) deleted", id).to_string()
-                    ),
-                    Err(e) => eprintln!("{}", format!("Error: {}", e).to_string()),
+                    Ok(_) => println!("{}", format!("Notification (id: {}) deleted", id)),
+                    Err(e) => eprintln!("{}", format!("Error: {}", e)),
                 };
                 debug!("Message::Delete done");
             } else {
@@ -221,10 +218,7 @@ async fn create_notification<'a>(
     );
     let mut hash_map = hash_map.lock().unwrap();
     hash_map.insert(id, handle);
-    println!(
-        "{}",
-        format!("Notification (id: {}) created", id).to_string()
-    );
+    println!("{}", format!("Notification (id: {}) created", id));
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,10 @@
+use clap::ArgMatches;
 use gluesql::{memory_storage::Key, Glue, MemoryStorage};
 use std::collections::HashMap;
 use std::error::Error;
 use std::io::{self, Write};
 use std::process;
 use std::sync::{Arc, Mutex};
-use tokio::sync::mpsc::{self};
-use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 use tokio::time::sleep;
 
@@ -27,11 +26,6 @@ extern crate log;
 type TaskMap = HashMap<u16, JoinHandle<()>>;
 type ArcGlue = Arc<Mutex<Glue<Key, MemoryStorage>>>;
 
-struct UserInput {
-    pub command: String,
-    pub oneshot_tx: oneshot::Sender<String>,
-}
-
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     initialize_logging();
@@ -51,167 +45,92 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let mut id_manager: u16 = 1;
     let hash_map: Arc<Mutex<TaskMap>> = Arc::new(Mutex::new(HashMap::new()));
 
-    let (tx, mut rx) = mpsc::channel::<UserInput>(64);
-    let tx_for_command = tx.clone();
-
-    tokio::spawn(async move {
-        loop {
-            debug!("inside spawn blocking");
-            let command = read_command();
-            debug!("user input: {}", &command);
-
-            let (oneshot_tx, oneshot_rx) = oneshot::channel::<String>();
-
-            debug!("command: {:?}", command);
-
-            let _ = tx_for_command
-                .send(UserInput {
-                    command,
-                    oneshot_tx,
-                })
-                .await;
-
-            let result = oneshot_rx.await.unwrap();
-
-            if !result.is_empty() {
-                info!("{}", result);
-            }
-        }
-    });
-
-    while let Some(input) = rx.recv().await {
-        let UserInput {
-            command,
-            oneshot_tx,
-        } = input;
-
-        let app = argument::get_app();
-        let input = command.split_whitespace();
-
-        debug!("input: {:?}", input);
-
-        let matches = match app.get_matches_from_safe(input) {
-            Err(err) => {
-                match err.kind {
-                    // HelpDisplayed has help message in error
-                    clap::ErrorKind::HelpDisplayed => {
-                        print!("\n{}\n", err);
-                        let _ = oneshot_tx.send("".to_string());
-                    }
-                    // clap automatically print version string with out newline.
-                    clap::ErrorKind::VersionDisplayed => {
-                        println!();
-                        let _ = oneshot_tx.send("".to_string());
-                    }
-                    _ => {
-                        print!("\n{}\n", err);
-                        let _ = oneshot_tx.send("".to_string());
-                    }
-                }
-                continue;
-            }
-            Ok(arg) => arg,
+    loop {
+        debug!("inside spawn blocking");
+        let command = read_command();
+        debug!("user input: {}", &command);
+        if let Err(e) =
+            analyze_input(&command, &mut id_manager, &hash_map, &glue, &configuration).await
+        {
+            println!("There was an error analyzing the input: {}", e);
         };
-
-        match matches.subcommand() {
-            (CREATE, Some(sub_matches)) => {
-                let (work_time, break_time) = if sub_matches.is_present("default") {
-                    (DEFAULT_WORK_TIME, DEFAULT_BREAK_TIME)
-                } else {
-                    let work_time = parse_arg::<u16>(sub_matches, "work")?;
-                    let break_time = parse_arg::<u16>(sub_matches, "break")?;
-
-                    (work_time, break_time)
-                };
-
-                debug!("work_time: {}", work_time);
-                debug!("break_time: {}", break_time);
-
-                if work_time == 0 && break_time == 0 {
-                    let _ = oneshot_tx.send(
-                        String::from("work_time and break_time both can not be zero both")
-                            .to_string(),
-                    );
-                    continue;
-                }
-
-                let id = get_new_id(&mut id_manager);
-
-                db::create_notification(
-                    glue.clone(),
-                    &Notification::new(id, work_time, break_time),
-                )
-                .await;
-
-                let handle = spawn_notification(
-                    id,
-                    work_time,
-                    break_time,
-                    configuration.clone(),
-                    hash_map.clone(),
-                    glue.clone(),
-                );
-
-                let mut hash_map = hash_map.lock().unwrap();
-                hash_map.insert(id, handle);
-
-                let _ = oneshot_tx.send(format!("Notification (id: {}) created", id).to_string());
-            }
-            (DELETE, Some(sub_matches)) => {
-                if sub_matches.is_present("id") {
-                    // delete one
-                    let id = parse_arg::<u16>(sub_matches, "id")?;
-
-                    debug!("Message::Delete called! {}", id);
-
-                    let result = delete_notification(id, hash_map.clone(), glue.clone()).await;
-
-                    let message = match result {
-                        Ok(_) => format!("Notification (id: {}) deleted", id).to_string(),
-                        Err(e) => format!("Error: {}", e).to_string(),
-                    };
-
-                    debug!("Message::Delete done");
-                    let _ = oneshot_tx.send(message);
-                } else {
-                    // delete all
-                    debug!("Message:DeleteAll called!");
-
-                    let hash_map = hash_map.lock().unwrap();
-                    for (_, handle) in hash_map.iter() {
-                        handle.abort();
-                    }
-                    db::delete_all_notification(glue.clone()).await;
-
-                    debug!("Message::DeleteAll done");
-                    let _ = oneshot_tx.send(String::from("All notifications deleted"));
-                }
-            }
-            (LS, Some(_)) | (LIST, Some(_)) => {
-                debug!("Message::Query called!");
-                db::list_notification(glue.clone()).await;
-                debug!("Message::Query done");
-
-                let _ = oneshot_tx.send(String::from("Query succeed"));
-            }
-            (TEST, Some(_)) => {
-                debug!("Message:NotificationTest called!");
-                notify_work(&configuration.clone()).await?;
-                debug!("Message:NotificationTest done");
-
-                let _ = oneshot_tx.send(String::from("NotificationTest called"));
-            }
-            (CLEAR, Some(_)) => {
-                print!("\x1B[2J");
-                let _ = oneshot_tx.send("".to_string());
-            }
-            (EXIT, Some(_)) => {
-                process::exit(0);
-            }
-            _ => {}
-        }
     }
+}
 
+async fn analyze_input(
+    command: &str,
+    id_manager: &mut u16,
+    hash_map: &Arc<Mutex<TaskMap>>,
+    glue: &Arc<Mutex<Glue<Key, MemoryStorage>>>,
+    configuration: &Arc<Configuration>,
+) -> Result<(), Box<dyn Error>> {
+    let app = argument::get_app();
+    let input = command.split_whitespace();
+    debug!("input: {:?}", input);
+    let matches = match app.get_matches_from_safe(input) {
+        Ok(args) => args,
+        Err(result) => {
+            // TODO: Makes this like the default implementation
+            eprintln!("Error");
+            return Err(Box::new(result));
+        }
+    };
+
+    match matches.subcommand() {
+        (CREATE, Some(sub_matches)) => {
+            if let Err(e) =
+                create_notification(sub_matches, configuration, hash_map, glue, id_manager).await
+            {
+                return Err(e);
+            };
+        }
+        (DELETE, Some(sub_matches)) => {
+            if sub_matches.is_present("id") {
+                // delete one
+                let id = parse_arg::<u16>(sub_matches, "id")?;
+
+                debug!("Message::Delete called! {}", id);
+
+                let result = delete_notification(id, hash_map.clone(), glue.clone()).await;
+
+                let message = match result {
+                    Ok(_) => format!("Notification (id: {}) deleted", id).to_string(),
+                    Err(e) => format!("Error: {}", e).to_string(),
+                };
+                debug!("Message::Delete done");
+            } else {
+                // delete all
+                debug!("Message:DeleteAll called!");
+
+                let hash_map = hash_map.lock().unwrap();
+                for (_, handle) in hash_map.iter() {
+                    handle.abort();
+                }
+                db::delete_all_notification(glue.clone()).await;
+
+                debug!("Message::DeleteAll done");
+            }
+        }
+        (LS, Some(_)) | (LIST, Some(_)) => {
+            debug!("Message::Query called!");
+            db::list_notification(glue.clone()).await;
+            debug!("Message::Query done");
+            println!("Query succeed");
+        }
+        (TEST, Some(_)) => {
+            debug!("Message:NotificationTest called!");
+            notify_work(&configuration.clone()).await?;
+            debug!("Message:NotificationTest done");
+            println!("Notification Test called");
+        }
+        (CLEAR, Some(_)) => {
+            print!("\x1B[2J");
+        }
+        (EXIT, Some(_)) => {
+            process::exit(0);
+        } // _ => Err(Box::new(),
+        _ => (),
+    };
     Ok(())
 }
 
@@ -254,6 +173,45 @@ fn read_command() -> String {
     let command = command.trim().to_string();
 
     command
+}
+
+async fn create_notification<'a>(
+    matches: &ArgMatches<'a>,
+    configuration: &Arc<Configuration>,
+    hash_map: &Arc<Mutex<TaskMap>>,
+    glue: &ArcGlue,
+    id_manager: &mut u16,
+) -> Result<(), Box<dyn Error>> {
+    let (work_time, break_time) = if matches.is_present("default") {
+        (DEFAULT_WORK_TIME, DEFAULT_BREAK_TIME)
+    } else {
+        let work_time = parse_arg::<u16>(matches, "work")?;
+        let break_time = parse_arg::<u16>(matches, "break")?;
+
+        (work_time, break_time)
+    };
+
+    debug!("work_time: {}", work_time);
+    debug!("break_time: {}", break_time);
+
+    if work_time == 0 && break_time == 0 {
+        println!("work_time and break_time both can not be zero both");
+    }
+
+    let id = get_new_id(id_manager);
+    db::create_notification(glue.clone(), &Notification::new(id, work_time, break_time)).await;
+
+    let handle = spawn_notification(
+        id,
+        work_time,
+        break_time,
+        configuration.clone(),
+        hash_map.clone(),
+        glue.clone(),
+    );
+    let mut hash_map = hash_map.lock().unwrap();
+    hash_map.insert(id, handle);
+    Ok(())
 }
 
 async fn delete_notification(

--- a/src/main.rs
+++ b/src/main.rs
@@ -182,8 +182,8 @@ fn read_command() -> String {
     command
 }
 
-async fn create_notification<'a>(
-    matches: &ArgMatches<'a>,
+async fn create_notification(
+    matches: &ArgMatches<'_>,
     configuration: &Arc<Configuration>,
     hash_map: &Arc<Mutex<TaskMap>>,
     glue: &ArcGlue,

--- a/src/main.rs
+++ b/src/main.rs
@@ -203,6 +203,9 @@ async fn create_notification(
 
     if work_time == 0 && break_time == 0 {
         eprintln!("work_time and break_time both can not be zero both");
+        // TODO: This shouldn't return Ok, since it is an error, but for now,
+        // is just a "temporal fix" for returning from the function.
+        return Ok(());
     }
 
     let id = get_new_id(id_manager);

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,11 +89,7 @@ async fn analyze_input(
 
     match matches.subcommand() {
         (CREATE, Some(sub_matches)) => {
-            if let Err(e) =
-                create_notification(sub_matches, configuration, hash_map, glue, id_manager).await
-            {
-                return Err(e);
-            };
+            create_notification(sub_matches, configuration, hash_map, glue, id_manager).await?;
         }
         (DELETE, Some(sub_matches)) => {
             if sub_matches.is_present("id") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,7 +114,7 @@ async fn analyze_input(
                     handle.abort();
                 }
                 db::delete_all_notification(glue.clone()).await;
-
+                println!("NotificationTest called");
                 debug!("Message::DeleteAll done");
             }
         }


### PR DESCRIPTION
As listed in issue: #16, the pomodoro main thread can handle more operations sequentially without the overhead of creating tokio threads.

It should be noted that the CREATE option has  been refactored and moved to a separate method, but it would still be quite necessary a refactor for the whole system (isolating different logics, like for example the DataBase logic has to be completely decoupled from main.rs, the parsing arguments part should be delegated to argument.rs, and so much more) but this has to be thinked and talked in another issue.

In addition, I can say that theoretically this pull request does not break any of the current functionalities of the code (since I have tested the application and it seems to work the same as before), although, as at the moment there are no unit tests, I cannot ensure that this is true for the 100% of cases.