### PR TITLE
Alert correctly when the notification queued

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -4,7 +4,7 @@ use gluesql::{
     storages::memory_storage::Key,
 };
 use std::sync::{Arc, Mutex};
-use tabled::{Table, Style};
+use tabled::{Style, Table};
 
 use crate::notification::Notification;
 use crate::ArcGlue;
@@ -135,7 +135,9 @@ pub async fn list_notification(glue: ArcGlue) {
         Payload::Select { labels: _, rows } => {
             let notifications = rows.into_iter().map(Notification::convert_to_notification);
 
-            let table = Table::new(notifications).with(Style::pseudo_clean()).to_string();
+            let table = Table::new(notifications)
+                .with(Style::pseudo_clean())
+                .to_string();
 
             info!("\n{}", table);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -334,6 +334,11 @@ fn spawn_notification(
         let (id, _, work_time, break_time, _, _, _) = notification.get_values();
         debug!("id: {}, task started", id);
 
+        let before_start_remaining = (notification.get_start_at() - Utc::now()).num_seconds();
+        let before = tokio::time::Duration::from_secs(before_start_remaining as u64);
+        debug!("before_start_remaining: {:?}", before_start_remaining);
+        sleep(before).await;
+
         if work_time > 0 {
             let wt = tokio::time::Duration::from_secs(work_time as u64 * 60);
             sleep(wt).await;

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -42,6 +42,13 @@ impl<'a> Notification {
         self.id
     }
 
+    pub fn get_start_at(&self) -> DateTime<Utc> {
+        let last_expired_at = self.work_expired_at.max(self.break_expired_at);
+        let duration = Duration::minutes((self.work_time + self.break_time) as i64);
+
+        last_expired_at - duration
+    }
+
     pub fn get_values(
         &'a self,
     ) -> (
@@ -163,10 +170,7 @@ impl Tabled for Notification {
         };
 
         let start_at = {
-            let last_expired_at = self.work_expired_at.max(self.break_expired_at);
-            let duration = Duration::minutes((self.work_time + self.break_time) as i64);
-
-            let local_time: DateTime<Local> = (last_expired_at - duration).into();
+            let local_time: DateTime<Local> = self.get_start_at().into();
             local_time.format("%F %T %z").to_string()
         };
 


### PR DESCRIPTION
While using it, I found the bug that when the notification is created by `queue` command, then the alert rings incorrect timing.
So I made a fix