### PR TITLE
move cursor to top when clear

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -139,7 +139,7 @@ async fn analyze_input(
             println!("Notification Test called");
         }
         (CLEAR, Some(_)) => {
-            print!("\x1B[2J");
+            print!("\x1B[2J\x1B[1;1H");
         }
         (EXIT, Some(_)) => {
             process::exit(0);


### PR DESCRIPTION
I found in google. Using this character makes cursor to top and clear the terminal. Tested on Ubuntu 20.04