### PR TITLE
Support notification history

### DIFF
--- a/src/archived_notification.rs
+++ b/src/archived_notification.rs
@@ -1,0 +1,137 @@
+use chrono::{prelude::*, Duration};
+use tabled::Tabled;
+
+use crate::notification::Notification;
+
+#[derive(Debug)]
+pub struct ArchivedNotification {
+    id: u16,
+    description: String,
+    work_time: u16,
+    break_time: u16,
+    // TODO(young): Maybe we don't need created_at field for ArchivedNotification
+    created_at: DateTime<Utc>,
+    work_expired_at: DateTime<Utc>,
+    break_expired_at: DateTime<Utc>,
+}
+
+impl From<Notification> for ArchivedNotification {
+    fn from(n: Notification) -> Self {
+        let (id, desc, wt, bt, created_at, w_expired_at, b_expired_at) = n.get_values();
+
+        ArchivedNotification {
+            id,
+            description: desc.to_string(),
+            work_time: wt,
+            break_time: bt,
+            created_at,
+            work_expired_at: w_expired_at,
+            break_expired_at: b_expired_at,
+        }
+    }
+}
+
+impl ArchivedNotification {
+    pub fn get_start_at(&self) -> DateTime<Utc> {
+        let last_expired_at = self.work_expired_at.max(self.break_expired_at);
+        let duration = Duration::minutes((self.work_time + self.break_time) as i64);
+
+        last_expired_at - duration
+    }
+}
+
+impl Tabled for ArchivedNotification {
+    const LENGTH: usize = 5;
+
+    fn fields(&self) -> Vec<String> {
+        let id = self.id.to_string();
+
+        let started_at = {
+            let local_time: DateTime<Local> = self.get_start_at().into();
+            local_time.format("%F %T %z").to_string()
+        };
+
+        let description = self.description.to_string();
+
+        let work_expired_at = if self.work_time > 0 {
+            let local_time: DateTime<Local> = self.work_expired_at.into();
+            local_time.format("%F %T %z").to_string()
+        } else {
+            String::from("N/A")
+        };
+
+        let break_expired_at = if self.break_time > 0 {
+            let local_time: DateTime<Local> = self.break_expired_at.into();
+            local_time.format("%F %T %z").to_string()
+        } else {
+            String::from("N/A")
+        };
+
+        vec![
+            id,
+            started_at,
+            work_expired_at,
+            break_expired_at,
+            description,
+        ]
+    }
+
+    fn headers() -> Vec<String> {
+        vec![
+            "id",
+            "started_at",
+            "expired_at (work)",
+            "expired_at (break)",
+            "description",
+        ]
+        .into_iter()
+        .map(|x| x.to_string())
+        .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::notification::Notification;
+    use chrono::Utc;
+    use tabled::Tabled;
+
+    use super::ArchivedNotification;
+
+    #[test]
+    fn test_archived_notification_conversion() {
+        let now = Utc::now();
+        let notification = Notification::new(0, 25, 5, now);
+        let archived_notification = ArchivedNotification::from(notification);
+
+        assert_eq!(
+            now.to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+            archived_notification
+                .get_start_at()
+                .to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+        );
+    }
+
+    #[test]
+    fn test_archived_notification_tabled_impl() {
+        let now = Utc::now();
+        let notification = Notification::new(0, 25, 5, now);
+        let archived_notification = ArchivedNotification::from(notification);
+
+        let fields = archived_notification.fields();
+        assert_eq!(5, fields.len());
+
+        let headers = ArchivedNotification::headers();
+        assert_eq!(5, headers.len());
+        assert_eq!(
+            vec![
+                "id".to_string(),
+                "started_at".to_string(),
+                "expired_at (work)".to_string(),
+                "expired_at (break)".to_string(),
+                "description".to_string(),
+            ],
+            headers
+        );
+    }
+}

--- a/src/argument.rs
+++ b/src/argument.rs
@@ -14,6 +14,7 @@ pub const DEFAULT_BREAK_TIME: u16 = 5;
 pub const TEST: &str = "test";
 pub const EXIT: &str = "exit";
 pub const CLEAR: &str = "clear";
+pub const HISTORY: &str = "history";
 
 pub fn get_config_app() -> App<'static, 'static> {
     App::new("pomodoro").arg(
@@ -63,6 +64,7 @@ pub fn get_app() -> App<'static, 'static> {
                 ),
             SubCommand::with_name(LIST).about("list notifications long command"),
             SubCommand::with_name(LS).about("list notifications short command"),
+            SubCommand::with_name(HISTORY).about("show archived notifications"),
             SubCommand::with_name(TEST).about("test notification"),
             SubCommand::with_name(CLEAR).about("clear terminal"),
             SubCommand::with_name(EXIT).about("exit pomodoro app"),

--- a/src/database.rs
+++ b/src/database.rs
@@ -5,8 +5,8 @@ use gluesql::{
 };
 use std::sync::{Arc, Mutex};
 
-use crate::notification::Notification;
 use crate::ArcGlue;
+use crate::{archived_notification::ArchivedNotification, notification::Notification};
 
 pub fn get_memory_glue() -> Glue<Key, MemoryStorage> {
     let storage = MemoryStorage::default();
@@ -21,6 +21,13 @@ pub async fn initialize(glue: Arc<Mutex<Glue<Key, MemoryStorage>>>) {
         "DROP TABLE IF EXISTS notifications;",
         r#"
         CREATE TABLE notifications (
+            id INTEGER, description TEXT, 
+            work_time INTEGER, break_time INTEGER, 
+            created_at TIMESTAMP, 
+            work_expired_at TIMESTAMP, break_expired_at TIMESTAMP,
+        );"#,
+        r#"DROP TABLE IF EXISTS archived_notifications;"#,
+        r#"CREATE TABLE archived_notifications (
             id INTEGER, description TEXT, 
             work_time INTEGER, break_time INTEGER, 
             created_at TIMESTAMP, 
@@ -141,6 +148,37 @@ pub async fn list_notification(glue: ArcGlue) -> Vec<Notification> {
     }
 }
 
+pub async fn list_archived_notification(glue: ArcGlue) -> Vec<ArchivedNotification> {
+    let mut glue = glue.lock().unwrap();
+
+    let sql = "SELECT * FROM archived_notifications ORDER BY id DESC;";
+
+    let output = glue.execute(sql).unwrap();
+    debug!("output: {:?}", output);
+
+    match output {
+        Payload::Select { labels: _, rows } => rows
+            .into_iter()
+            // TODO(young): As of now archived_notifications schema is same as notifications table
+            .map(Notification::convert_to_notification)
+            .map(|n| {
+                let archived_notification = ArchivedNotification::from(n);
+
+                archived_notification
+            })
+            .collect(),
+        _ => {
+            panic!("no such case!");
+        }
+    }
+}
+
+pub async fn delete_and_archive_notification(glue: ArcGlue, id: u16) {
+    archive_notification(glue.clone(), id).await;
+    delete_notification(glue.clone(), id).await;
+}
+
+//TODO(young): Handle error?
 pub async fn delete_notification(glue: ArcGlue, id: u16) {
     let mut glue = glue.lock().unwrap();
 
@@ -170,6 +208,24 @@ pub async fn delete_notification(glue: ArcGlue, id: u16) {
     debug!("output: {:?}", output);
 }
 
+//TODO(young): Handle error?
+pub async fn archive_notification(glue: ArcGlue, id: u16) {
+    let mut glue = glue.lock().unwrap();
+
+    let sql = format!(
+        r#"
+    INSERT INTO archived_notifications
+    SELECT * FROM notifications WHERE id = {};
+    "#,
+        id
+    );
+
+    debug!("sql: {:?}", sql);
+
+    let output = glue.execute(sql.as_str()).unwrap();
+    debug!("output: {:?}", output);
+}
+
 pub async fn delete_all_notification(glue: ArcGlue) {
     let mut glue = glue.lock().unwrap();
 
@@ -190,8 +246,9 @@ mod tests {
     use gluesql::prelude::{Payload, PayloadVariable};
 
     use super::{
-        create_notification, delete_all_notification, delete_notification, get_memory_glue,
-        initialize, list_notification, read_last_expired_notification, read_notification,
+        archive_notification, create_notification, delete_all_notification, delete_notification,
+        get_memory_glue, initialize, list_archived_notification, list_notification,
+        read_last_expired_notification, read_notification,
     };
     use std::{
         panic,
@@ -207,9 +264,12 @@ mod tests {
         let output = glue.lock().unwrap().execute(sql).unwrap();
 
         match output {
-            Payload::ShowVariable(PayloadVariable::Tables(names)) => {
-                assert_eq!(1, names.len());
-                assert_eq!("notifications", names[0]);
+            Payload::ShowVariable(PayloadVariable::Tables(mut names)) => {
+                names.sort();
+
+                assert_eq!(2, names.len());
+                assert_eq!("archived_notifications", names[0]);
+                assert_eq!("notifications", names[1]);
             }
             _ => {
                 panic!("no such case");
@@ -294,6 +354,24 @@ mod tests {
         delete_all_notification(glue.clone()).await;
         let result = list_notification(glue.clone()).await;
         assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_archive_notification() {
+        let glue = Arc::new(Mutex::new(get_memory_glue()));
+        initialize(glue.clone()).await;
+
+        let now = Utc::now();
+        let notification = Notification::new(0, 25, 5, now);
+        create_notification(glue.clone(), &notification).await;
+
+        archive_notification(glue.clone(), 0).await;
+
+        let result = list_notification(glue.clone()).await;
+        assert!(result.len() == 1);
+
+        let result = list_archived_notification(glue.clone()).await;
+        assert!(result.len() == 1);
     }
 
     #[tokio::test]

--- a/src/database.rs
+++ b/src/database.rs
@@ -161,11 +161,7 @@ pub async fn list_archived_notification(glue: ArcGlue) -> Vec<ArchivedNotificati
             .into_iter()
             // TODO(young): As of now archived_notifications schema is same as notifications table
             .map(Notification::convert_to_notification)
-            .map(|n| {
-                let archived_notification = ArchivedNotification::from(n);
-
-                archived_notification
-            })
+            .map(ArchivedNotification::from)
             .collect(),
         _ => {
             panic!("no such case!");

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,10 +1,10 @@
-fn get_package_name() -> String {
-    let package_name = env!("CARGO_PKG_NAME");
-    package_name.replace('-', "_")
+fn get_binary_name() -> String {
+    let binary_name = env!("CARGO_BIN_NAME");
+    binary_name.to_string()
 }
 
 pub fn initialize_logging() {
-    let package_name = &get_package_name();
+    let package_name = &get_binary_name();
 
     if cfg!(debug_assertions) {
         env_logger::Builder::from_default_env()
@@ -19,11 +19,11 @@ pub fn initialize_logging() {
 
 #[cfg(test)]
 mod tests {
-    use super::get_package_name;
+    use super::get_binary_name;
 
     #[test]
-    fn test_get_package_name() {
-        let package_name = get_package_name();
-        assert_eq!("rust_cli_pomodoro", package_name);
+    fn test_get_binary_name() {
+        let binary_name = get_binary_name();
+        assert_eq!("pomodoro", binary_name);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use tabled::{Style, TableIteratorExt};
 use tokio::task::JoinHandle;
 use tokio::time::sleep;
 
+mod archived_notification;
 mod argument;
 mod database;
 mod notification;
@@ -130,6 +131,9 @@ async fn analyze_input(
         (LS, Some(_)) | (LIST, Some(_)) => {
             handle_list(glue).await;
         }
+        (HISTORY, Some(_)) => {
+            handle_history(glue).await;
+        }
         (TEST, Some(_)) => {
             handle_test(configuration).await?;
         }
@@ -156,6 +160,20 @@ async fn handle_list(glue: &Arc<Mutex<Glue<Key, MemoryStorage>>>) {
     info!("\n{}", table);
 
     println!("List succeed");
+}
+
+async fn handle_history(glue: &Arc<Mutex<Glue<Key, MemoryStorage>>>) {
+    debug!("Message:History called!");
+    let archived_notifications = db::list_archived_notification(glue.clone()).await;
+    debug!("Message:History done!");
+
+    let table = archived_notifications
+        .table()
+        .with(Style::modern().horizontal_off())
+        .to_string();
+    info!("\n{}", table);
+
+    println!("History succeed");
 }
 
 async fn handle_test(configuration: &Arc<Configuration>) -> Result<(), Box<dyn Error>> {
@@ -262,7 +280,7 @@ async fn delete_notification(
             .ok_or(format!("failed to remove id ({})", id))?;
     }
 
-    db::delete_notification(glue, id).await;
+    db::delete_and_archive_notification(glue, id).await;
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ mod configuration;
 mod input_handler;
 mod logging;
 
-use crate::argument::{parse_arg, CLEAR, CREATE, DELETE, EXIT, LIST, LS, Q, QUEUE, TEST};
+use crate::argument::{parse_arg, CLEAR, CREATE, DELETE, EXIT, HISTORY, LIST, LS, Q, QUEUE, TEST};
 use crate::configuration::{initialize_configuration, Configuration};
 use crate::notification::{notify_break, notify_work, Notification};
 
@@ -123,7 +123,7 @@ async fn analyze_input(
                 for (_, handle) in hash_map.iter() {
                     handle.abort();
                 }
-                db::delete_all_notification(glue.clone()).await;
+                db::delete_and_archive_all_notification(glue.clone()).await;
                 println!("All Notifications deleted");
                 debug!("Message::DeleteAll done");
             }

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -435,7 +435,4 @@ mod tests {
             headers
         );
     }
-
-    #[tokio::test]
-    async fn test_send_slack() {}
 }


### PR DESCRIPTION
## Description

There would be many options to implement `history` feature.
For me, I need this feature to check how many pomodoros did I consumed.

Based on this purpose, there are two options in my mind
1. add `archived` column for differentiating the archived and non-archived notifications
2. store archived notification in separated table, `archived_notifications` for example.

For me, it seems separating is more attractive because I don't have to care about when focusing on `notifications` table and vice versa. This would save the cost in the future I hope..