### PR TITLE
Friendly credential json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi-parser"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcb2392079bf27198570d6af79ecbd9ec7d8f16d3ec6b60933922fdb66287127"
+dependencies = [
+ "heapless",
+ "nom",
+]
+
+[[package]]
+name = "ansi-str"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90cb0ceb8c444d026166795e474e9dfe54b443bdc07cc21bd6c5073f5e637482"
+dependencies = [
+ "ansi-parser",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -31,6 +50,18 @@ name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
+name = "as-slice"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45403b49e3954a4b8428a0ac21a4b7afadccf92bfd96273f1a58cd4812496ae0"
+dependencies = [
+ "generic-array 0.12.4",
+ "generic-array 0.13.3",
+ "generic-array 0.14.5",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "async-io"
@@ -282,6 +313,17 @@ checksum = "2f3e1238132dc01f081e1cbb9dace14e5ef4c3a51ee244bd982275fb514605db"
 dependencies = [
  "error-code",
  "str-buf",
+ "winapi",
+]
+
+[[package]]
+name = "colored"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
+dependencies = [
+ "atty",
+ "lazy_static",
  "winapi",
 ]
 
@@ -705,6 +747,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f797e67af32588215eaaab8327027ee8e71b9dd0b2b26996aedf20c030fce309"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
+dependencies = [
+ "typenum",
+ "version_check 0.9.3",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -851,10 +921,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4041af86e63ac4298ce40e5cca669066e75b6f1aa3390fe2561ffa5e1d9f4cc"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "heapless"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74911a68a1658cfcfb61bc0ccfbd536e3b6e906f8c2f7883ee50157e3e2184f1"
+dependencies = [
+ "as-slice",
+ "generic-array 0.13.3",
+ "hash32",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "heck"
@@ -979,7 +1070,7 @@ dependencies = [
  "rand_xoshiro",
  "sized-chunks",
  "typenum",
- "version_check",
+ "version_check 0.9.3",
 ]
 
 [[package]]
@@ -1232,6 +1323,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "4.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
+dependencies = [
+ "memchr",
+ "version_check 0.1.5",
+]
+
+[[package]]
 name = "notify-rust"
 version = "4.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1377,6 +1478,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c2b5b9ea36abb56e4f8a29889e67f878ebc4ab43c918abe32e85a012d27b819"
 dependencies = [
+ "strip-ansi-escapes",
  "unicode-width",
 ]
 
@@ -1574,7 +1676,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "version_check",
+ "version_check 0.9.3",
 ]
 
 [[package]]
@@ -1585,7 +1687,7 @@ checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2",
  "quote",
- "version_check",
+ "version_check 0.9.3",
 ]
 
 [[package]]
@@ -1800,6 +1902,7 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "clap 2.33.3",
+ "colored",
  "env_logger",
  "gluesql",
  "log",
@@ -2077,6 +2180,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2087,6 +2196,15 @@ name = "str-buf"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d44a3643b4ff9caf57abcee9c2c621d6c03d9135e0d8b589bd9afb5992cb176a"
+
+[[package]]
+name = "strip-ansi-escapes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "011cbb39cf7c1f62871aea3cc46e5817b0937b49e9447370c93cacbe93a766d8"
+dependencies = [
+ "vte",
+]
 
 [[package]]
 name = "strsim"
@@ -2157,6 +2275,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85fda0a52a50c85604747c6584cc79cfe6c7b6ee2349ffed082f965bdbef77ef"
 dependencies = [
+ "ansi-str",
  "papergrid",
  "tabled_derive",
 ]
@@ -2361,7 +2480,7 @@ version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baeed7327e25054889b9bd4f975f32e5f4c5d434042d59ab6cd4142c0a76ed0"
 dependencies = [
- "version_check",
+ "version_check 0.9.3",
 ]
 
 [[package]]
@@ -2438,6 +2557,12 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+
+[[package]]
+name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
@@ -2447,6 +2572,27 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "vte"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cbce692ab4ca2f1f3047fcf732430249c0e971bfdd2b234cf2c47ad93af5983"
+dependencies = [
+ "arrayvec",
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte_generate_state_changes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d257817081c7dffcdbab24b9e62d2def62e2ff7d00b1c20062551e6cccc145ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "waker-fn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,11 @@ gluesql = { version = "0.10.2", features = ["memory-storage"] }
 notify-rust = "4.5.4"
 log = "0.4.0"
 env_logger = "0.9.0"
-tabled = "0.5.0"
+tabled = { version = "0.5.0", features = ["color"]}
 serde_json = "1.0.59"
 serde = "1.0.130"
 reqwest = { version = "0.11", features = ["json"] }
+colored = "2"
 
 [[bin]]
 name = "pomodoro"

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -1,4 +1,6 @@
+use colored::{ColoredString, Colorize};
 use serde::Deserialize;
+use tabled::{Style, Table, Tabled};
 
 use std::env;
 use std::error::Error;
@@ -6,6 +8,8 @@ use std::ffi::OsStr;
 use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;
+
+use crate::error::ConfigurationError;
 
 pub const SLACK_API_URL: &str = "https://slack.com/api/chat.postMessage";
 
@@ -53,40 +57,114 @@ impl Configuration {
 
 pub fn initialize_configuration(
     credential_file: Option<&str>,
-) -> Result<Configuration, Box<dyn Error>> {
-    let configuration = match credential_file {
+) -> Result<(Configuration, Option<ConfigurationError>), Box<dyn Error>> {
+    let (configuration, error) = match credential_file {
         Some(f) => {
             let path = env::current_dir()?.join(f);
 
-            get_configuration_from_file(path)?
+            match get_configuration_from_file(path) {
+                Ok(config) => (config, None),
+                Err(e) => (Configuration::default(), Some(e)),
+            }
         }
-        None => Configuration::default(),
+        None => (Configuration::default(), None),
     };
 
     debug!("configuration: {:?}", configuration);
 
-    Ok(configuration)
+    Ok((configuration, error))
 }
 
 fn get_configuration_from_file<P: AsRef<Path> + AsRef<OsStr>>(
     path: P,
-) -> Result<Configuration, Box<dyn Error>> {
+) -> Result<Configuration, ConfigurationError> {
     if !Path::new(&path).exists() {
-        return Ok(Configuration::default());
+        return Err(ConfigurationError::FileNotFound);
     }
 
-    let file = File::open(path)?;
+    let file = File::open(path).map_err(ConfigurationError::FileOpenError)?;
     let reader = BufReader::new(file);
 
-    let c = serde_json::from_reader(reader)?;
+    let c = serde_json::from_reader(reader).map_err(ConfigurationError::JsonError)?;
     Ok(c)
+}
+
+#[derive(Tabled)]
+struct Report {
+    ok: ColoredString,
+    desc: String,
+    reason: ColoredString,
+}
+
+impl Report {
+    pub fn new(ok: &'static str, desc: &'static str) -> Self {
+        Report {
+            ok: ok.green(),
+            desc: String::from(desc),
+            reason: ColoredString::default(),
+        }
+    }
+
+    // TODO(young): e should be string or ConfigurationError?
+    pub fn update_reason(mut self, e: ConfigurationError) -> Self {
+        let mut vec = vec![format!("{}", e)];
+        if let Some(s) = e.source() {
+            vec.push(s.to_string());
+        }
+
+        self.reason = vec.join("\n").red();
+
+        self
+    }
+}
+
+pub fn generate_configuration_report(
+    config: &Configuration,
+    err: Option<ConfigurationError>,
+) -> String {
+    let config_err_message = match err {
+        Some(e) => Report::new("X", "config err").update_reason(e),
+        None => Report::new("O", "config err"),
+    };
+
+    let slack_channel_message = match config.get_slack_channel() {
+        // TODO(young): Reason?
+        Some(_) => Report::new("O", "slack_channel"),
+        None => {
+            Report::new("X", "slack_channel").update_reason(ConfigurationError::SlackConfigNotFound)
+        }
+    };
+
+    let slack_token_message = match config.get_slack_channel() {
+        // TODO(young): Reason?
+        Some(_) => Report::new("O", "slack_token"),
+        None => {
+            Report::new("X", "slack_token").update_reason(ConfigurationError::SlackConfigNotFound)
+        }
+    };
+
+    let discord_webhook_url_message = match config.get_discord_webhook_url() {
+        // TODO(young): Reason?
+        Some(_) => Report::new("O", "discord_webhook_url"),
+        None => Report::new("X", "discord_webhook_url")
+            .update_reason(ConfigurationError::DiscordConfigNotFound),
+    };
+
+    Table::new(vec![
+        config_err_message,
+        slack_channel_message,
+        slack_token_message,
+        discord_webhook_url_message,
+    ])
+    .with(Style::modern())
+    .to_string()
 }
 
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
 
-    use super::{get_configuration_from_file, initialize_configuration};
+    use super::initialize_configuration;
 
     #[test]
     fn test_initialize_configuration_some() {
@@ -95,7 +173,7 @@ mod tests {
 
         let result = initialize_configuration(file);
         assert_eq!(true, result.is_ok());
-        let config = result.unwrap();
+        let config = result.0.unwrap();
 
         let slack_token = config.get_slack_token();
         assert_eq!(true, slack_token.is_some());
@@ -117,7 +195,7 @@ mod tests {
             .for_each(|file| {
                 let result = initialize_configuration(file);
                 assert_eq!(true, result.is_ok());
-                let config = result.unwrap();
+                let config = result.0.unwrap();
 
                 let slack_token = config.get_slack_token();
                 assert_eq!(true, slack_token.is_none());

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -173,7 +173,7 @@ mod tests {
 
         let result = initialize_configuration(file);
         assert_eq!(true, result.is_ok());
-        let config = result.0.unwrap();
+        let config = result.unwrap().0;
 
         let slack_token = config.get_slack_token();
         assert_eq!(true, slack_token.is_some());
@@ -195,7 +195,7 @@ mod tests {
             .for_each(|file| {
                 let result = initialize_configuration(file);
                 assert_eq!(true, result.is_ok());
-                let config = result.0.unwrap();
+                let config = result.unwrap().0;
 
                 let slack_token = config.get_slack_token();
                 assert_eq!(true, slack_token.is_none());

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,9 @@
 use notify_rust::error::Error as NotifyRustError;
 use reqwest::Error as RequestError;
-use std::fmt;
+use serde_json::error::Error as SerdeJsonError;
+use std::{fmt, io, result};
+
+pub type NotifyResult = result::Result<(), NotificationError>;
 
 // notification error enum
 #[derive(Debug)]
@@ -32,6 +35,44 @@ impl std::error::Error for NotificationError {
             NotificationError::Slack(ref e) => Some(e),
             NotificationError::Discord(ref e) => Some(e),
             NotificationError::EmptyConfiguration => None,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum ConfigurationError {
+    FileNotFound,
+    FileOpenError(io::Error),
+    JsonError(SerdeJsonError),
+    SlackConfigNotFound,
+    DiscordConfigNotFound,
+    // config json wrong format?
+}
+
+impl fmt::Display for ConfigurationError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ConfigurationError::FileNotFound => write!(f, "can not find configuration file "),
+            ConfigurationError::FileOpenError(_) => write!(f, "failed to open the file"),
+            ConfigurationError::JsonError(_) => write!(f, "failed to deserialize json"),
+            ConfigurationError::SlackConfigNotFound => {
+                write!(f, "can not find slack config in json")
+            }
+            ConfigurationError::DiscordConfigNotFound => {
+                write!(f, "can not find discord config in json")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ConfigurationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            ConfigurationError::FileNotFound => None,
+            ConfigurationError::FileOpenError(ref e) => Some(e),
+            ConfigurationError::JsonError(ref e) => Some(e),
+            ConfigurationError::SlackConfigNotFound => None,
+            ConfigurationError::DiscordConfigNotFound => None,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,9 @@ mod logging;
 mod notify;
 
 use crate::argument::{parse_arg, CLEAR, CREATE, DELETE, EXIT, HISTORY, LIST, LS, Q, QUEUE, TEST};
-use crate::configuration::{initialize_configuration, Configuration};
+use crate::configuration::{
+    generate_configuration_report, initialize_configuration, Configuration,
+};
 use crate::notification::Notification;
 use crate::notify::{notify_break, notify_work};
 
@@ -39,14 +41,16 @@ pub type ArcGlue = Arc<Mutex<Glue<Key, MemoryStorage>>>;
 async fn main() -> Result<(), Box<dyn Error>> {
     logging::initialize_logging();
 
+    info!("info test, start pomodoro...");
+    debug!("debug test, start pomodoro...");
+
     let config_matches = argument::get_config_app().get_matches();
     let credential_file_path = config_matches.value_of("config");
 
-    let configuration = initialize_configuration(credential_file_path)?;
+    let (configuration, config_error) = initialize_configuration(credential_file_path)?;
+    let report = generate_configuration_report(&configuration, config_error);
+    info!("\nconfig flag result!\n{}", report);
     let configuration = Arc::new(configuration);
-
-    info!("info test, start pomodoro...");
-    debug!("debug test, start pomodoro...");
 
     let glue = Arc::new(Mutex::new(db::get_memory_glue()));
     db::initialize(glue.clone()).await;


### PR DESCRIPTION
## Description
To provide whether `--config` option is successfully applied or not, print `configuration report` at the beginning of the application starts.

While working on this feature, I found table could be colorized. So I added little color for `configuration report` and `notify report`.

### Demo

#### Run pomodoro without --config option
<img width="677" alt="image" src="https://user-images.githubusercontent.com/34280965/161426738-83e9f9f1-0ef9-420f-baaf-1bdd8cc23b14.png">

#### Run pomodoro wiht proper option
<img width="649" alt="image" src="https://user-images.githubusercontent.com/34280965/161426758-5421b943-9ccb-48a3-820d-15fddc6d71f8.png">

