### PR TITLE
Follow version metadata in app

### DIFF
--- a/src/argument.rs
+++ b/src/argument.rs
@@ -17,7 +17,7 @@ pub const CLEAR: &str = "clear";
 pub const HISTORY: &str = "history";
 
 pub fn get_config_app() -> App<'static, 'static> {
-    App::new("pomodoro").arg(
+    App::new("pomodoro").version(env!("CARGO_PKG_VERSION")).arg(
         Arg::with_name("config")
             .help("read credential json file from this path")
             .takes_value(true)
@@ -29,7 +29,7 @@ pub fn get_config_app() -> App<'static, 'static> {
 pub fn get_app() -> App<'static, 'static> {
     App::new("pomodoro")
         .setting(AppSettings::NoBinaryName)
-        .version("1.0.0")
+        .version(env!("CARGO_PKG_VERSION"))
         .version_short("v")
         .author("Young")
         .about("manage your time!")

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -95,7 +95,7 @@ async fn notify_discord(message: &'static str, configuration: &Arc<Configuration
     resp.map(|_| ()).map_err(NotificationError::Discord)
 }
 
-/// notify_dekstop send notification to desktop.
+/// notify_desktop send notification to desktop.
 /// use notify-rust library for desktop notification
 async fn notify_desktop(summary_message: &'static str, body_message: &'static str) -> NotifyResult {
     let mut notification = NR_Notification::new();


### PR DESCRIPTION
## Description

I found that version input doesn't correctly match the current version.
To automatically match the `Cargo.toml` version, I used `env!("CARGO_PKG_VERSION")`. 