### PR TITLE
Modify checkbox uses in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,19 +147,19 @@ pomodoro --config ./credential.json
 
 - [ ] Run previous command if needed
 - [ ] Command auto completion
-- [o] Write test cases 
+- [ ] Write integration tests
 - [ ] More rich notification: sound, app icon, hint, action etc
-- [o] Provide more notification delivery option: Currently pomodoro uses desktop notification. But notification could be delivered through slack, email or any kind of method.
-    - [v] slack integration
-    - [v] discord integration
+- [ ] Provide more notification delivery option: Currently pomodoro uses desktop notification. But notification could be delivered through slack, email or any kind of method.
+    - [x] slack integration
+    - [x] discord integration
     - what else?
-- [o] Provide an easy way to use this app (brew, snap, cargo install, etc..)
-    - [v] cargo install
+- [ ] Provide an easy way to use this app (brew, snap, cargo install, etc..)
+    - [x] cargo install
 
 
 ------
 
-- [v] Support mac os (>= 11.0.0) notification: Currently [notify-rust](https://github.com/hoodie/notify-rust) uses [mac-notification-sys](https://github.com/h4llow3En/mac-notification-sys) but `mac-notification_sys` doesn't support recent mac version (as of 17:10 Sun 17 Oct 2021) => published binary can send desktop notification without problem (01:21 Fri 13 May 2022)
+- [x] Support mac os (>= 11.0.0) notification: Currently [notify-rust](https://github.com/hoodie/notify-rust) uses [mac-notification-sys](https://github.com/h4llow3En/mac-notification-sys) but `mac-notification_sys` doesn't support recent mac version (as of 17:10 Sun 17 Oct 2021) => published binary can send desktop notification without problem (01:21 Fri 13 May 2022)
 
 
 ## Compatibility


### PR DESCRIPTION
3-state checkbox is not supported in Markdown syntax.
Uses of `[o]` or `[v]` look broken in rendered document.
Replace to `[v]` use `[x]`.
Change "Write test cases" roadmap to "Write integration tests" and unchecked it. (there exists unit tests, only integration tests are missing)

### Current state
* GitHub repo README.md
https://github.com/24seconds/rust-cli-pomodoro#roadmap
![image](https://user-images.githubusercontent.com/2025065/168331182-4948bb47-d8a7-4373-a998-200bfad0cb18.png)

* Crates.io - rust-cli-pomodoro
https://crates.io/crates/rust-cli-pomodoro
![image](https://user-images.githubusercontent.com/2025065/168331292-c33dbf2a-0f8b-4a9e-88b8-c70f786adf21.png)

### PR changes
![image](https://user-images.githubusercontent.com/2025065/168331429-cb3ffe66-9f26-4bef-b62d-d77719c9349d.png)
