### PR TITLE
Fix bug: IPC command delete not work

### DIFF
--- a/src/command/application.rs
+++ b/src/command/application.rs
@@ -86,7 +86,8 @@ fn get_common_subcommands() -> Vec<Command<'static>> {
             .arg(
                 Arg::new("all")
                     .help("The flag to delete all notifications")
-                    .short('a'),
+                    .short('a')
+                    .long("all"),
             ),
         Command::new(ActionType::List)
             .alias(LS)

--- a/src/command/application.rs
+++ b/src/command/application.rs
@@ -80,7 +80,8 @@ fn get_common_subcommands() -> Vec<Command<'static>> {
                     .help("The ID of notification to delete")
                     .takes_value(true)
                     .conflicts_with("all")
-                    .short('i'),
+                    .short('i')
+                    .long("id"),
             )
             .arg(
                 Arg::new("all")

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -67,7 +67,7 @@ impl From<MessageRequest> for UserInput {
                 if all {
                     format!("{} -a", String::from(ActionType::Delete))
                 } else {
-                    format!("{} -id {}", String::from(ActionType::Delete), id)
+                    format!("{} -i {}", String::from(ActionType::Delete), id)
                 }
             }
             MessageRequest::List => String::from(ActionType::List),


### PR DESCRIPTION
## Description
When passing `MessageRequest`, delete message is not constructed with correct argument.
So I fix that part and now it works.

## Comment
This bug should be caught in early stage if I wrote the test case about `MessageRequest`