### PR TITLE
Increase BUFFER LENGTH

### DIFF
--- a/src/command/handler/uds_client.rs
+++ b/src/command/handler/uds_client.rs
@@ -8,7 +8,7 @@ use crate::command::util;
 use crate::error::UdsHandlerError;
 use crate::ipc::{MessageRequest, MessageResponse};
 
-pub const BUFFER_LENGTH: usize = 1_000_000;
+pub const BUFFER_LENGTH: usize = 100_000_000;
 
 type HandleUdsResult = result::Result<(), UdsHandlerError>;
 


### PR DESCRIPTION
## Description
While using the `pomodoro` heavily, I found that `BUFFER_LENGTH` is quite small.
`1_000_000` byte is 1MB. So I increased it to 100MB