### PR TITLE
Build sql statement using `ast builder`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -652,8 +652,7 @@ dependencies = [
 [[package]]
 name = "gluesql"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9083e6aeeeef1a3367d878f336adcb417e5ce7dabac9e852981d41aeaa676aeb"
+source = "git+https://github.com/gluesql/gluesql?branch=main#3a604c93dddd9e4dcc47357ee3ecce22299709b0"
 dependencies = [
  "gluesql-core",
  "gluesql_memory_storage",
@@ -662,8 +661,7 @@ dependencies = [
 [[package]]
 name = "gluesql-core"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4ad33156fb7b3fd0ff616af4ed4482c90c47ba11c4323ece3559e17129ff7e"
+source = "git+https://github.com/gluesql/gluesql?branch=main#3a604c93dddd9e4dcc47357ee3ecce22299709b0"
 dependencies = [
  "async-recursion 1.0.0",
  "async-trait",
@@ -690,8 +688,7 @@ dependencies = [
 [[package]]
 name = "gluesql-utils"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed8961df91f129f68c9fa87dc48d47d7e4d646f34ad295d9122114ac28977e6"
+source = "git+https://github.com/gluesql/gluesql?branch=main#3a604c93dddd9e4dcc47357ee3ecce22299709b0"
 dependencies = [
  "futures",
  "indexmap",
@@ -701,8 +698,7 @@ dependencies = [
 [[package]]
 name = "gluesql_memory_storage"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5811aac0d18719542f60bba38d3ebb58867a846fa6fbe4a0e16d920d5ec46377"
+source = "git+https://github.com/gluesql/gluesql?branch=main#3a604c93dddd9e4dcc47357ee3ecce22299709b0"
 dependencies = [
  "async-trait",
  "gluesql-core",
@@ -1800,9 +1796,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f531637a13132fa3d38c54d4cd8f115905e5dc3e72f6e77bd6160481f482e25d"
+checksum = "d8ec7ef1bad82a2453dbaef7218b6f036e545edcce1ffd55f6e7af7bea43cce2"
 dependencies = [
  "bigdecimal",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ tokio = { version = "1.19.2", features = ["macros", "rt-multi-thread", "time", "
 clap = "3.2.18"
 chrono = "0.4.22"
 chrono-tz=  "0.6.3"
-gluesql = { version = "0.12.0", default-features = false, features = ["memory-storage"] }
+gluesql = { git = "https://github.com/gluesql/gluesql", branch = "main", default-features = false, features = ["memory-storage"] }
 notify-rust = "4.5.8"
 log = "0.4.17"
 env_logger = "0.9.0"

--- a/src/database.rs
+++ b/src/database.rs
@@ -113,16 +113,14 @@ pub async fn read_last_expired_notification(glue: ArcGlue) -> Option<Notificatio
 pub async fn read_notification(glue: ArcGlue, id: u16) -> Option<Notification> {
     let mut glue = glue.lock().unwrap();
 
-    let sql = format!(
-        r#"
-        SELECT * FROM notifications WHERE id = {};
-        "#,
-        id
-    );
+    let sql_stmt = table("notifications")
+        .select()
+        .filter(format!("id = {}", id).as_str())
+        .build()
+        .unwrap();
+    debug!("sql_stmt: {:?}", sql_stmt);
 
-    debug!("sql: {:?}", sql);
-
-    let output = glue.execute(sql.as_str()).unwrap().swap_remove(0);
+    let output = glue.execute_stmt(&sql_stmt).unwrap();
     debug!("output: {:?}", output);
 
     match output {
@@ -145,9 +143,9 @@ pub async fn read_notification(glue: ArcGlue, id: u16) -> Option<Notification> {
 pub async fn list_notification(glue: ArcGlue) -> Vec<Notification> {
     let mut glue = glue.lock().unwrap();
 
-    let sql = "SELECT * FROM notifications;";
+    let sql_stmt = table("notifications").select().build().unwrap();
 
-    let output = glue.execute(sql).unwrap().swap_remove(0);
+    let output = glue.execute_stmt(&sql_stmt).unwrap();
     debug!("output: {:?}", output);
 
     match output {
@@ -192,28 +190,24 @@ pub async fn delete_notification(glue: ArcGlue, id: u16) {
     let mut glue = glue.lock().unwrap();
 
     // check if notification exists. It's okay. glue executes commands sequentially as of now.
-    let sql = format!(
-        r#"
-        SELECT * FROM notifications WHERE id = {};
-        "#,
-        id
-    );
+    let sql_stmt = table("notifications")
+        .select()
+        .filter(format!("id = {}", id).as_str())
+        .build()
+        .unwrap();
+    debug!("sql_stmt: {:?}", sql_stmt);
 
-    debug!("sql: {:?}", sql);
-
-    let output = glue.execute(sql.as_str()).unwrap();
+    let output = glue.execute_stmt(&sql_stmt).unwrap();
     debug!("output: {:?}", output);
 
-    let sql = format!(
-        r#"
-        DELETE FROM notifications WHERE id = {};
-        "#,
-        id
-    );
+    let sql_stmt = table("notifications")
+        .delete()
+        .filter(format!("id = {}", id).as_str())
+        .build()
+        .unwrap();
+    debug!("delete sql_stmt: {:?}", sql_stmt);
 
-    debug!("delete sql: {}", sql);
-
-    let output = glue.execute(sql.as_str()).unwrap();
+    let output = glue.execute_stmt(&sql_stmt).unwrap();
     debug!("output: {:?}", output);
 }
 
@@ -252,13 +246,10 @@ pub async fn archive_all_notification(glue: ArcGlue) {
 pub async fn delete_all_notification(glue: ArcGlue) {
     let mut glue = glue.lock().unwrap();
 
-    let sql = r#"
-        DELETE FROM notifications;
-    "#;
+    let sql_stmt = table("notifications").delete().build().unwrap();
+    debug!("delete sql_stmt: {:?}", sql_stmt);
 
-    debug!("delete sql: {}", sql);
-
-    let output = glue.execute(sql).unwrap();
+    let output = glue.execute_stmt(&sql_stmt).unwrap();
     debug!("output: {:?}", output);
 }
 

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,4 +1,5 @@
 use chrono::SecondsFormat;
+use gluesql::core::ast_builder::table;
 use gluesql::prelude::{Glue, MemoryStorage, Payload};
 use std::sync::{Arc, Mutex};
 
@@ -14,26 +15,41 @@ pub fn get_memory_glue() -> Glue<MemoryStorage> {
 pub async fn initialize(glue: Arc<Mutex<Glue<MemoryStorage>>>) {
     let mut glue = glue.lock().unwrap();
 
-    let sqls = vec![
-        "DROP TABLE IF EXISTS notifications;",
-        r#"
-        CREATE TABLE notifications (
-            id INTEGER, description TEXT, 
-            work_time INTEGER, break_time INTEGER, 
-            created_at TIMESTAMP, 
-            work_expired_at TIMESTAMP, break_expired_at TIMESTAMP,
-        );"#,
-        r#"DROP TABLE IF EXISTS archived_notifications;"#,
-        r#"CREATE TABLE archived_notifications (
-            id INTEGER, description TEXT, 
-            work_time INTEGER, break_time INTEGER, 
-            created_at TIMESTAMP, 
-            work_expired_at TIMESTAMP, break_expired_at TIMESTAMP,
-        );"#,
+    let sql_stmts = vec![
+        table("notifications")
+            .drop_table_if_exists()
+            .build()
+            .unwrap(),
+        table("notifications")
+            .create_table()
+            .add_column("id INTEGER")
+            .add_column("description TEXT")
+            .add_column("work_time INTEGER")
+            .add_column("break_time INTEGER")
+            .add_column("created_at TIMESTAMP")
+            .add_column("work_expired_at TIMESTAMP")
+            .add_column("break_expired_at TIMESTAMP")
+            .build()
+            .unwrap(),
+        table("archived_notifications")
+            .drop_table_if_exists()
+            .build()
+            .unwrap(),
+        table("archived_notifications")
+            .create_table()
+            .add_column("id INTEGER")
+            .add_column("description TEXT")
+            .add_column("work_time INTEGER")
+            .add_column("break_time INTEGER")
+            .add_column("created_at TIMESTAMP")
+            .add_column("work_expired_at TIMESTAMP")
+            .add_column("break_expired_at TIMESTAMP")
+            .build()
+            .unwrap(),
     ];
 
-    for sql in sqls {
-        let output = glue.execute(sql).unwrap();
+    for stmt in sql_stmts {
+        let output = glue.execute_stmt(&stmt).unwrap();
         debug!("output: {:?}", output);
     }
 }


### PR DESCRIPTION
## Description
As gluesql version `0.12.0` is [released](https://github.com/gluesql/gluesql/releases/tag/v0.12.0), `AST builder` feature is introduced. 

To use this early stage feature, I replaced `sql strings` to `sql statements` at my best.
Because I used unreleased features, I changed gluesql package import path temporarily.

## Note
This pr should not change to current behavior.