### PR TITLE
Fix cargo build failure due to bump up clap version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,22 +304,24 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.8"
+version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5840cd9093aabeabf7fd932754c435b7674520fc3ddc935c397837050f0f1e4b"
+checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
  "atty",
  "bitflags",
  "clap_lex",
+ "indexmap",
  "strsim",
  "termcolor",
+ "textwrap",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.3.0"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
@@ -1936,6 +1938,12 @@ checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = ["/assets"]
 
 [dependencies]
 tokio = { version = "1.19.2", features = ["macros", "rt-multi-thread", "time", "sync"] }
-clap = "4.0.8"
+clap = "3.2.22"
 chrono = "0.4.22"
 chrono-tz=  "0.6.3"
 gluesql = { git = "https://github.com/gluesql/gluesql", branch = "main", default-features = false, features = ["memory-storage"] }

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,5 +1,5 @@
 use chrono::SecondsFormat;
-use gluesql::core::ast_builder::table;
+use gluesql::core::ast_builder::{table, Build};
 use gluesql::prelude::{Glue, MemoryStorage, Payload};
 use std::sync::{Arc, Mutex};
 


### PR DESCRIPTION
Hello, I am appreciative of this repository :pray:

With this [PR](https://github.com/24seconds/rust-cli-pomodoro/pull/112), the major version of clap has bump up, causing `cargo build` to fail. 
As a temporary solution, I am downgrading the major version of clap. 
Additionally, I have added the usage of `gluesql::core::ast_builder::Build` as it was necessary for the current version of gluesql.
