### PR TITLE
Fix test command yield wrong notification configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ cargo install rust-cli-pomodoro
 
 ### Using credential.json
 pomodoro support slack notification.
-To use it, you need to create `credential.json` file in somewhere in your local machine. `credential.json` supports two keys, `slack` and `discrod`.
+To use it, you need to create `credential.json` file in somewhere in your local machine. `credential.json` supports two keys, `slack` and `discord`.
 The `slack` and `discord` value is json. It looks like this
 
 ```json

--- a/src/command/util.rs
+++ b/src/command/util.rs
@@ -68,6 +68,7 @@ mod tests {
 
     use super::{parse_arg, read_input};
 
+    #[test]
     fn test_parse_arg() {
         let m = Command::new("myapp")
             .arg(Arg::new("id").takes_value(true))

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,7 +35,7 @@ impl fmt::Display for NotificationError {
             NotificationError::Discord(_) => write!(f, "NotificationError::Discord"),
             NotificationError::EmptyConfiguration => write!(f, "configuration is empty"),
             NotificationError::NewNotification(e) => {
-                write!(f, "faield to get new notification: {}", e)
+                write!(f, "failed to get new notification: {}", e)
             }
             NotificationError::DeletionFail(msg) => write!(f, "{}", msg),
         }

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -268,7 +268,7 @@ fn create_uds_address(r#type: UdsType, should_remove: bool) -> std::io::Result<P
     let path = get_uds_address(r#type);
 
     if should_remove && path.exists() {
-        debug!("patt {:?} exists, remove it before binding", &path);
+        debug!("path {:?} exists, remove it before binding", &path);
         fs::remove_file(&path)?;
     }
 

--- a/src/notification/notify.rs
+++ b/src/notification/notify.rs
@@ -126,8 +126,8 @@ pub async fn notify_work(configuration: &Arc<Configuration>) -> Result<String, N
     let (desktop_result, slack_result, discord_result) = join!(desktop_fut, slack_fut, discord_fut);
 
     Ok(report::generate_notify_report(
-        slack_result,
         desktop_result,
+        slack_result,
         discord_result,
     ))
 }


### PR DESCRIPTION
- Fixed three typos
- Added a missing #[test]
- Fixed a `generate_notify_report` call which was being called using the wrong order of variables causing the misinformation on the `test` command

#138

