### PR TITLE
update version to v1.3.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1735,7 +1735,7 @@ dependencies = [
 
 [[package]]
 name = "rust-cli-pomodoro"
-version = "1.3.3"
+version = "1.3.4"
 dependencies = [
  "bincode",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-cli-pomodoro"
-version = "1.3.3"
+version = "1.3.4"
 authors = ["24seconds <24crazyoung@gmail.com>"]
 edition = "2021"
 rust-version = "1.59"


### PR DESCRIPTION
## Description
This pr updates cargo package version. Maybe it would be nice to automate this process later. For example, when I add the label named `deployment` then the github action would trigger to publish the new version.