### PR TITLE
Apply default values when no value is passed

### DIFF
--- a/resources/test/mock_configuration.json
+++ b/resources/test/mock_configuration.json
@@ -6,6 +6,6 @@
   "discord": {
       "webhook_url": "your-webhook-url"
   },
-  "work_time_default_value": 25,
-  "break_time_default_value": 5
+  "work_time_default_value": 30,
+  "break_time_default_value": 10
 }

--- a/resources/test/mock_configuration.json
+++ b/resources/test/mock_configuration.json
@@ -5,5 +5,7 @@
   },
   "discord": {
       "webhook_url": "your-webhook-url"
-  }
+  },
+  "work_time_default_value": 25,
+  "break_time_default_value": 5
 }

--- a/src/command/application.rs
+++ b/src/command/application.rs
@@ -115,19 +115,29 @@ pub(crate) fn add_args_for_create_subcommand(command: Command) -> Command {
     command
         .arg(
             Arg::new("work")
-                .help("The focus time. Unit is minutes")
+                .long_help("The focus time in minutes.
+If no value is passed, the work time is obtained from `work_time_default_value` in the given configuration file.
+And if no configuration file is passed or `work_time_default_value` is not present, then 25 is used as the work time.
+")
                 .num_args(1)
                 .short('w'),
         )
         .arg(
             Arg::new("break")
-                .help("The break time, Unit is minutes")
+                .long_help("The break time in minutes.
+If no value is passed, the break time is obtained from `break_time_default_value` in the given configuration file.
+And if no configuration file is passed or `break_time_default_value` is not present, then 5 is used as the break time.
+")
                 .num_args(1)
                 .short('b'),
         )
         .arg(
             Arg::new("default")
-                .help("The flag to create default notification, 25 mins work and 5 min break")
+                .long_help(
+                    "The flag to create default notification.
+The values are obtained from `work_time_default_value` and `break_time_default_value` in the given configuration file.
+If no configuration file is passed or the keys are not present, then 25 minutes for work and 5 minutes for break is considered.
+")
                 .conflicts_with("work")
                 .conflicts_with("break")
                 .short('d')

--- a/src/command/application.rs
+++ b/src/command/application.rs
@@ -117,15 +117,13 @@ pub(crate) fn add_args_for_create_subcommand(command: Command) -> Command {
             Arg::new("work")
                 .help("The focus time. Unit is minutes")
                 .num_args(1)
-                .short('w')
-                .default_value("0"),
+                .short('w'),
         )
         .arg(
             Arg::new("break")
                 .help("The break time, Unit is minutes")
                 .num_args(1)
-                .short('b')
-                .default_value("0"),
+                .short('b'),
         )
         .arg(
             Arg::new("default")

--- a/src/command/application.rs
+++ b/src/command/application.rs
@@ -35,7 +35,7 @@ pub fn get_start_and_uds_client_command() -> Command {
         .args_conflicts_with_subcommands(true)
         .arg(
             Arg::new("config")
-                .help("read credential json file from this path")
+                .help("Read configuration json file from this path")
                 .num_args(1)
                 .short('c')
                 .long("config"),

--- a/src/command/handler/user_input.rs
+++ b/src/command/handler/user_input.rs
@@ -103,39 +103,27 @@ async fn handle_create(
     let notification = get_new_notification(matches, id_manager, Utc::now())
         .map_err(UserInputHandlerError::NotificationError)?;
 
-    match notification {
-        Some(notification) => {
-            let id = notification.get_id();
-            db::create_notification(glue.clone(), &notification).await;
+    let id = notification.get_id();
+    db::create_notification(glue.clone(), &notification).await;
 
-            let handle = spawn_notification(
-                configuration.clone(),
-                notification_task_map.clone(),
-                glue.clone(),
-                notification,
-            );
+    let handle = spawn_notification(
+        configuration.clone(),
+        notification_task_map.clone(),
+        glue.clone(),
+        notification,
+    );
 
-            notification_task_map.lock().unwrap().insert(id, handle);
-            output_accumulator.push(
-                OutputType::Println,
-                format!(
-                    "[{}] Notification (id: {}) created",
-                    chrono::offset::Local::now(),
-                    id
-                ),
-            );
+    notification_task_map.lock().unwrap().insert(id, handle);
+    output_accumulator.push(
+        OutputType::Println,
+        format!(
+            "[{}] Notification (id: {}) created",
+            chrono::offset::Local::now(),
+            id
+        ),
+    );
 
-            Ok(())
-        }
-        None => {
-            output_accumulator.push(
-                OutputType::Println,
-                String::from("work_time and break_time both can not be zero both"),
-            );
-
-            Ok(())
-        }
-    }
+    Ok(())
 }
 
 async fn handle_queue(
@@ -158,33 +146,28 @@ async fn handle_queue(
 
     let notification = get_new_notification(matches, id_manager, created_at)
         .map_err(UserInputHandlerError::NotificationError)?;
-    match notification {
-        Some(notification) => {
-            let id = notification.get_id();
-            db::create_notification(glue.clone(), &notification).await;
+    let id = notification.get_id();
+    db::create_notification(glue.clone(), &notification).await;
 
-            notification_task_map.lock().unwrap().insert(
-                id,
-                spawn_notification(
-                    configuration.clone(),
-                    notification_task_map.clone(),
-                    glue.clone(),
-                    notification,
-                ),
-            );
-            output_accumulator.push(
-                OutputType::Println,
-                format!(
-                    "[{}] Notification (id: {}) created and queued",
-                    chrono::offset::Local::now(),
-                    id
-                ),
-            );
+    notification_task_map.lock().unwrap().insert(
+        id,
+        spawn_notification(
+            configuration.clone(),
+            notification_task_map.clone(),
+            glue.clone(),
+            notification,
+        ),
+    );
+    output_accumulator.push(
+        OutputType::Println,
+        format!(
+            "[{}] Notification (id: {}) created and queued",
+            chrono::offset::Local::now(),
+            id
+        ),
+    );
 
-            Ok(())
-        }
-        None => Ok(()),
-    }
+    Ok(())
 }
 
 async fn handle_delete(

--- a/src/command/handler/user_input.rs
+++ b/src/command/handler/user_input.rs
@@ -100,7 +100,7 @@ async fn handle_create(
     id_manager: &mut u16,
     output_accumulator: &mut OutputAccumulater,
 ) -> HandleUserInputResult {
-    let notification = get_new_notification(matches, id_manager, Utc::now())
+    let notification = get_new_notification(matches, id_manager, Utc::now(), configuration.clone())
         .map_err(UserInputHandlerError::NotificationError)?;
 
     let id = notification.get_id();
@@ -144,7 +144,7 @@ async fn handle_queue(
         None => Utc::now(),
     };
 
-    let notification = get_new_notification(matches, id_manager, created_at)
+    let notification = get_new_notification(matches, id_manager, created_at, configuration.clone())
         .map_err(UserInputHandlerError::NotificationError)?;
     let id = notification.get_id();
     db::create_notification(glue.clone(), &notification).await;

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -12,7 +12,7 @@ use crate::report::generate_configuration_report;
 
 pub const SLACK_API_URL: &str = "https://slack.com/api/chat.postMessage";
 
-#[derive(Deserialize, Debug, Default)]
+#[derive(Deserialize, Debug, Default, Clone)]
 pub struct Configuration {
     #[serde(rename(deserialize = "slack"))]
     slack_configuration: Option<SlackConfiguration>,
@@ -22,13 +22,13 @@ pub struct Configuration {
     break_time_default_value: Option<u16>,
 }
 
-#[derive(Deserialize, Debug, Default)]
+#[derive(Deserialize, Debug, Default, Clone)]
 struct SlackConfiguration {
     token: Option<String>,
     channel: Option<String>,
 }
 
-#[derive(Deserialize, Debug, Default)]
+#[derive(Deserialize, Debug, Default, Clone)]
 struct DiscordConfiguration {
     webhook_url: Option<String>,
 }
@@ -139,11 +139,11 @@ mod tests {
 
         let work_time = config.get_work_time();
         assert_eq!(true, work_time.is_some());
-        assert_eq!(work_time.unwrap(), 25);
+        assert_eq!(work_time.unwrap(), 30);
 
         let break_time = config.get_break_time();
         assert_eq!(true, break_time.is_some());
-        assert_eq!(break_time.unwrap(), 5);
+        assert_eq!(break_time.unwrap(), 10);
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,6 +25,7 @@ pub enum NotificationError {
     EmptyConfiguration,
     NewNotification(ParseError),
     DeletionFail(String),
+    EmptyTimeValues,
 }
 
 impl fmt::Display for NotificationError {
@@ -38,6 +39,10 @@ impl fmt::Display for NotificationError {
                 write!(f, "failed to get new notification: {}", e)
             }
             NotificationError::DeletionFail(msg) => write!(f, "{}", msg),
+            NotificationError::EmptyTimeValues => write!(
+                f,
+                "Cannot create a notification with 0 work time and 0 break time"
+            ),
         }
     }
 }
@@ -51,6 +56,7 @@ impl std::error::Error for NotificationError {
             NotificationError::EmptyConfiguration => None,
             NotificationError::NewNotification(ref e) => Some(e),
             NotificationError::DeletionFail(_) => None,
+            NotificationError::EmptyTimeValues => None,
         }
     }
 }

--- a/src/notification/mod.rs
+++ b/src/notification/mod.rs
@@ -304,6 +304,7 @@ pub async fn delete_notification(
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
     use std::sync::Arc;
 
     use chrono::{Duration, NaiveDate, NaiveDateTime, NaiveTime, Utc};
@@ -420,7 +421,11 @@ mod tests {
         //With configuration file
 
         let (configuration, _) = load_configuration(Some(
-            &(env!("CARGO_MANIFEST_DIR").to_owned() + "/resources/test/mock_configuration.json"),
+            PathBuf::from(
+                env!("CARGO_MANIFEST_DIR").to_owned() + "/resources/test/mock_configuration.json",
+            )
+            .to_str()
+            .unwrap(),
         ))
         .unwrap();
 
@@ -458,7 +463,11 @@ mod tests {
         //with configuration file
 
         let (configuration, _) = load_configuration(Some(
-            &(env!("CARGO_MANIFEST_DIR").to_owned() + "/resources/test/mock_configuration.json"),
+            PathBuf::from(
+                env!("CARGO_MANIFEST_DIR").to_owned() + "/resources/test/mock_configuration.json",
+            )
+            .to_str()
+            .unwrap(),
         ))
         .unwrap();
 
@@ -493,7 +502,11 @@ mod tests {
 
         //with configuration file
         let (configuration, _) = load_configuration(Some(
-            &(env!("CARGO_MANIFEST_DIR").to_owned() + "/resources/test/mock_configuration.json"),
+            PathBuf::from(
+                env!("CARGO_MANIFEST_DIR").to_owned() + "/resources/test/mock_configuration.json",
+            )
+            .to_str()
+            .unwrap(),
         ))
         .unwrap();
 

--- a/src/notification/mod.rs
+++ b/src/notification/mod.rs
@@ -417,8 +417,11 @@ mod tests {
         let mut id_manager = 0;
         let now = Utc::now();
 
-        let (configuration, _) =
-            load_configuration(Some("./../../resources/test/mock_configuration.json")).unwrap();
+        let (configuration, _) = load_configuration(Some(
+            &(env!("CARGO_MANIFEST_DIR").to_owned() + "/resources/test/mock_configuration.json"),
+        ))
+        .unwrap();
+
         let notification =
             get_new_notification(&matches, &mut id_manager, now, Arc::new(configuration)).unwrap();
 

--- a/src/notification/mod.rs
+++ b/src/notification/mod.rs
@@ -223,30 +223,27 @@ impl Tabled for Notification {
     }
 }
 
-// TODO(young): Return error if work time and break time is zero
 pub fn get_new_notification(
     matches: &ArgMatches,
     id_manager: &mut u16,
     created_at: DateTime<Utc>,
-) -> Result<Option<Notification>, NotificationError> {
+) -> Result<Notification, NotificationError> {
     let (work_time, break_time) =
         util::parse_work_and_break_time(matches).map_err(NotificationError::NewNotification)?;
 
     debug!("work_time: {}", work_time);
     debug!("break_time: {}", break_time);
 
-    if work_time == 0 && break_time == 0 {
-        eprintln!("work_time and break_time both can not be zero both");
-        // TODO: This shouldn't return Ok, since it is an error, but for now,
-        // is just a "temporal fix" for returning from the function.
-        return Ok(None);
-    }
-
     let id = get_new_id(id_manager);
 
-    Ok(Some(Notification::new(
-        id, work_time, break_time, created_at,
-    )))
+    if work_time == 0 && break_time == 0 {
+        println!(
+            "NOTE: Creating a session with default values(25 minutes work time & 5 minutes break)"
+        );
+        return Ok(Notification::new(id, 25, 5, created_at));
+    }
+
+    Ok(Notification::new(id, work_time, break_time, created_at))
 }
 
 fn get_new_id(id_manager: &mut u16) -> u16 {
@@ -402,8 +399,6 @@ mod tests {
         let now = Utc::now();
 
         let notification = get_new_notification(&matches, &mut id_manager, now).unwrap();
-        assert!(notification.is_some());
-        let notification = notification.unwrap();
 
         let (id, _, wt, bt, created_at, _, _) = notification.get_values();
         assert_eq!(0, id);

--- a/src/notification/mod.rs
+++ b/src/notification/mod.rs
@@ -246,12 +246,14 @@ pub fn get_new_notification(
 
     if matches.get_one::<String>("work").is_some() {
         println!("work is some");
-        work_time = parse_arg::<u16>(matches, "work").map_err(NotificationError::NewNotification)?;
+        work_time =
+            parse_arg::<u16>(matches, "work").map_err(NotificationError::NewNotification)?;
     }
 
     if matches.get_one::<String>("break").is_some() {
         println!("break is some");
-        break_time = parse_arg::<u16>(matches, "break").map_err(NotificationError::NewNotification)?;
+        break_time =
+            parse_arg::<u16>(matches, "break").map_err(NotificationError::NewNotification)?;
     }
 
     debug!("work_time: {}", work_time);
@@ -417,8 +419,10 @@ mod tests {
         let mut id_manager = 0;
         let now = Utc::now();
 
-        let (configuration, _) = load_configuration(Some("./../../resources/test/mock_configuration.json")).unwrap();
-        let notification = get_new_notification(&matches, &mut id_manager, now, Arc::new(configuration)).unwrap(); 
+        let (configuration, _) =
+            load_configuration(Some("./../../resources/test/mock_configuration.json")).unwrap();
+        let notification =
+            get_new_notification(&matches, &mut id_manager, now, Arc::new(configuration)).unwrap();
 
         let (id, _, wt, bt, created_at, _, _) = notification.get_values();
         assert_eq!(0, id);

--- a/src/notification/mod.rs
+++ b/src/notification/mod.rs
@@ -245,13 +245,11 @@ pub fn get_new_notification(
     };
 
     if matches.get_one::<String>("work").is_some() {
-        println!("work is some");
         work_time =
             parse_arg::<u16>(matches, "work").map_err(NotificationError::NewNotification)?;
     }
 
     if matches.get_one::<String>("break").is_some() {
-        println!("break is some");
         break_time =
             parse_arg::<u16>(matches, "break").map_err(NotificationError::NewNotification)?;
     }

--- a/src/notification/mod.rs
+++ b/src/notification/mod.rs
@@ -410,12 +410,14 @@ mod tests {
     }
 
     #[test]
-    fn test_get_new_notification() {
+    fn test_create_new_notification_with_default_flag() {
         let cmd = Command::new("myapp");
         let matches = add_args_for_create_subcommand(cmd)
-            .get_matches_from("myapp -w 25 -b 5".split_whitespace());
+            .get_matches_from("myapp --default".split_whitespace());
         let mut id_manager = 0;
         let now = Utc::now();
+
+        //With configuration file
 
         let (configuration, _) = load_configuration(Some(
             &(env!("CARGO_MANIFEST_DIR").to_owned() + "/resources/test/mock_configuration.json"),
@@ -427,8 +429,173 @@ mod tests {
 
         let (id, _, wt, bt, created_at, _, _) = notification.get_values();
         assert_eq!(0, id);
+        assert_eq!(30, wt);
+        assert_eq!(10, bt);
+        assert_eq!(now, created_at);
+
+        //without configuration file
+
+        let (configuration, _) = load_configuration(Some("this_path_does_not_exist")).unwrap();
+
+        let notification =
+            get_new_notification(&matches, &mut id_manager, now, Arc::new(configuration)).unwrap();
+
+        let (id, _, wt, bt, created_at, _, _) = notification.get_values();
+        assert_eq!(1, id);
         assert_eq!(25, wt);
         assert_eq!(5, bt);
+        assert_eq!(now, created_at);
+    }
+
+    #[test]
+    fn test_create_new_notification_with_no_flag() {
+        let cmd = Command::new("myapp");
+        let matches =
+            add_args_for_create_subcommand(cmd).get_matches_from("myapp".split_whitespace());
+        let mut id_manager = 0;
+        let now = Utc::now();
+
+        //with configuration file
+
+        let (configuration, _) = load_configuration(Some(
+            &(env!("CARGO_MANIFEST_DIR").to_owned() + "/resources/test/mock_configuration.json"),
+        ))
+        .unwrap();
+
+        let notification =
+            get_new_notification(&matches, &mut id_manager, now, Arc::new(configuration)).unwrap();
+
+        let (id, _, wt, bt, created_at, _, _) = notification.get_values();
+        assert_eq!(0, id);
+        assert_eq!(30, wt);
+        assert_eq!(10, bt);
+        assert_eq!(now, created_at);
+
+        //without configuration file
+
+        let (configuration, _) = load_configuration(Some("this_path_does_not_exist")).unwrap();
+
+        let notification =
+            get_new_notification(&matches, &mut id_manager, now, Arc::new(configuration)).unwrap();
+
+        let (id, _, wt, bt, created_at, _, _) = notification.get_values();
+        assert_eq!(1, id);
+        assert_eq!(25, wt);
+        assert_eq!(5, bt);
+        assert_eq!(now, created_at);
+    }
+
+    #[test]
+    fn test_create_new_notification_with_flags() {
+        let cmd = Command::new("myapp");
+        let now = Utc::now();
+        let mut id_manager = 0;
+
+        //with configuration file
+        let (configuration, _) = load_configuration(Some(
+            &(env!("CARGO_MANIFEST_DIR").to_owned() + "/resources/test/mock_configuration.json"),
+        ))
+        .unwrap();
+
+        // -w x -b y
+        let matches = add_args_for_create_subcommand(cmd.clone())
+            .get_matches_from("myapp -w 50 -b 25".split_whitespace());
+
+        let notification = get_new_notification(
+            &matches,
+            &mut id_manager,
+            now,
+            Arc::new(configuration.clone()),
+        )
+        .unwrap();
+
+        let (id, _, wt, bt, created_at, _, _) = notification.get_values();
+        assert_eq!(0, id);
+        assert_eq!(50, wt);
+        assert_eq!(25, bt);
+        assert_eq!(now, created_at);
+
+        // -w x
+        let matches = add_args_for_create_subcommand(cmd.clone())
+            .get_matches_from("myapp -w 50".split_whitespace());
+
+        let notification = get_new_notification(
+            &matches,
+            &mut id_manager,
+            now,
+            Arc::new(configuration.clone()),
+        )
+        .unwrap();
+
+        let (id, _, wt, bt, created_at, _, _) = notification.get_values();
+        assert_eq!(1, id);
+        assert_eq!(50, wt);
+        assert_eq!(10, bt);
+        assert_eq!(now, created_at);
+
+        // -b y
+        let matches = add_args_for_create_subcommand(cmd.clone())
+            .get_matches_from("myapp -b 25".split_whitespace());
+
+        let notification =
+            get_new_notification(&matches, &mut id_manager, now, Arc::new(configuration)).unwrap();
+
+        let (id, _, wt, bt, created_at, _, _) = notification.get_values();
+        assert_eq!(2, id);
+        assert_eq!(30, wt);
+        assert_eq!(25, bt);
+        assert_eq!(now, created_at);
+
+        //without configuration file
+        let (configuration, _) = load_configuration(Some("this_path_does_not_exist")).unwrap();
+
+        // -w x -b y
+        let matches = add_args_for_create_subcommand(cmd.clone())
+            .get_matches_from("myapp -w 50 -b 25".split_whitespace());
+
+        let notification = get_new_notification(
+            &matches,
+            &mut id_manager,
+            now,
+            Arc::new(configuration.clone()),
+        )
+        .unwrap();
+
+        let (id, _, wt, bt, created_at, _, _) = notification.get_values();
+        assert_eq!(3, id);
+        assert_eq!(50, wt);
+        assert_eq!(25, bt);
+        assert_eq!(now, created_at);
+
+        // -w x
+        let matches = add_args_for_create_subcommand(cmd.clone())
+            .get_matches_from("myapp -w 50".split_whitespace());
+
+        let notification = get_new_notification(
+            &matches,
+            &mut id_manager,
+            now,
+            Arc::new(configuration.clone()),
+        )
+        .unwrap();
+
+        let (id, _, wt, bt, created_at, _, _) = notification.get_values();
+        assert_eq!(4, id);
+        assert_eq!(50, wt);
+        assert_eq!(5, bt);
+        assert_eq!(now, created_at);
+
+        // -b y
+        let matches =
+            add_args_for_create_subcommand(cmd).get_matches_from("myapp -b 25".split_whitespace());
+
+        let notification =
+            get_new_notification(&matches, &mut id_manager, now, Arc::new(configuration)).unwrap();
+
+        let (id, _, wt, bt, created_at, _, _) = notification.get_values();
+        assert_eq!(5, id);
+        assert_eq!(25, wt);
+        assert_eq!(25, bt);
         assert_eq!(now, created_at);
     }
 }

--- a/src/notification/mod.rs
+++ b/src/notification/mod.rs
@@ -10,6 +10,7 @@ use gluesql::core::data::Value;
 use gluesql::prelude::Row;
 use tabled::Tabled;
 
+use crate::command::{DEFAULT_BREAK_TIME, DEFAULT_WORK_TIME};
 use crate::db;
 use crate::error::NotificationError;
 use crate::{command::util, ArcGlue, ArcTaskMap};
@@ -240,7 +241,12 @@ pub fn get_new_notification(
         println!(
             "NOTE: Creating a session with default values(25 minutes work time & 5 minutes break)"
         );
-        return Ok(Notification::new(id, 25, 5, created_at));
+        return Ok(Notification::new(
+            id,
+            DEFAULT_WORK_TIME,
+            DEFAULT_BREAK_TIME,
+            created_at,
+        ));
     }
 
     Ok(Notification::new(id, work_time, break_time, created_at))


### PR DESCRIPTION
When no values specified, a notification is created with default values, this removes the need for a default flag.