### PR TITLE
Add Percentage column with list

### DIFF
--- a/src/command/application.rs
+++ b/src/command/application.rs
@@ -1,4 +1,4 @@
-use clap::{Arg, ArgAction, ArgMatches, Command};
+use clap::{Arg, ArgMatches, Command};
 use std::sync::Arc;
 
 use crate::command::action::ActionType;
@@ -105,7 +105,13 @@ fn get_common_subcommands() -> Vec<Command> {
             ),
         Command::new(ActionType::List)
             .alias(LS)
-            .about("list notifications"),
+            .about("list notifications")
+            .arg(
+                Arg::new("percentage")
+                    .short('p')
+                    .help("show work time completion percentage")
+                    .num_args(0),
+            ),
         Command::new(ActionType::History).about("show archived notifications"),
         Command::new(ActionType::Test).about("test notification"),
     ]
@@ -142,7 +148,7 @@ If no configuration file is passed or the keys are not present, then 25 minutes 
                 .conflicts_with("break")
                 .short('d')
                 .long("default")
-                .action(ArgAction::SetTrue),
+                .num_args(0),
         )
 }
 
@@ -232,6 +238,6 @@ mod tests {
         let matches =
             add_args_for_create_subcommand(cmd).get_matches_from("myapp -d".split_whitespace());
 
-        assert!(matches.contains_id("default"));
+        assert!(matches.get_flag("default"));
     }
 }

--- a/src/command/application.rs
+++ b/src/command/application.rs
@@ -239,5 +239,25 @@ mod tests {
             add_args_for_create_subcommand(cmd).get_matches_from("myapp -d".split_whitespace());
 
         assert!(matches.get_flag("default"));
+
+        // test work only
+        let cmd = Command::new("myapp");
+        let matches =
+            add_args_for_create_subcommand(cmd).get_matches_from("myapp -w 25".split_whitespace());
+        let work = matches.get_one::<String>("work").unwrap();
+        assert!(work.eq("25"));
+        assert!(matches.get_one::<String>("break").is_none());
+        assert_eq!(matches.get_flag("default"), false);
+        assert!(matches.contains_id("default"));
+
+        // test break only
+        let cmd = Command::new("myapp");
+        let matches =
+            add_args_for_create_subcommand(cmd).get_matches_from("myapp -b 10".split_whitespace());
+        let break_time = matches.get_one::<String>("break").unwrap();
+        assert!(break_time.eq("10"));
+        assert!(matches.get_one::<String>("work").is_none());
+        assert_eq!(matches.get_flag("default"), false);
+        assert!(matches.contains_id("default"));
     }
 }

--- a/src/command/util.rs
+++ b/src/command/util.rs
@@ -7,7 +7,7 @@ use clap::ArgMatches;
 use clap_complete::Shell;
 
 pub fn parse_work_and_break_time(matches: &ArgMatches) -> Result<(u16, u16), ParseError> {
-    let (work_time, break_time) = if matches.contains_id("default") {
+    let (work_time, break_time) = if matches.get_flag("default") {
         (DEFAULT_WORK_TIME, DEFAULT_BREAK_TIME)
     } else {
         let work_time = parse_arg::<u16>(matches, "work")?;

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -56,11 +56,11 @@ impl Configuration {
     }
 
     pub fn get_work_time(&self) -> Option<u16> {
-        return self.work_time_default_value;
+        self.work_time_default_value
     }
 
     pub fn get_break_time(&self) -> Option<u16> {
-        return self.break_time_default_value;
+        self.break_time_default_value
     }
 }
 


### PR DESCRIPTION
**Updates:**

- Fixed `create` and `queue` command not handling `-w` and`-b` and instead was using default values for all cases due to `contains_id` method returning `true`.
- Added `percentage` column when `-p` flag is passed with `ls`

Note: When using UDS, the app does not show the percentage column yet. Resolves #126.

Mistakenly closed #162 while resolving a conflict. 