### PR TITLE
Add clear history feature

### DIFF
--- a/src/command/application.rs
+++ b/src/command/application.rs
@@ -113,7 +113,15 @@ fn get_common_subcommands() -> Vec<Command> {
                     .help("show work time completion percentage")
                     .num_args(0),
             ),
-        Command::new(ActionType::History).about("show archived notifications"),
+        Command::new(ActionType::History)
+            .about("show archived notifications")
+            .arg(
+                Arg::new("clear")
+                    .help("The flag to delete all notifications from history")
+                    .short('c')
+                    .num_args(0)
+                    .long("clear"),
+            ),
         Command::new(ActionType::Test).about("test notification"),
     ]
 }


### PR DESCRIPTION
Handles flags `--clear` & `-c` for `history`. 
This is a first iteration, we could delete by `id` in the future

resolves #52 
