### PR TITLE
support history clear in ipc mode

### DIFF
--- a/src/command/handler/uds_client.rs
+++ b/src/command/handler/uds_client.rs
@@ -29,7 +29,7 @@ pub async fn handle(matches: ArgMatches, socket: UnixDatagram) -> HandleUdsResul
         ActionType::Delete => handle_delete(socket, sub_matches).await?,
         ActionType::List => handle_list(socket, sub_matches).await?,
         ActionType::Test => handle_test(socket).await?,
-        ActionType::History => handle_history(socket).await?,
+        ActionType::History => handle_history(socket, sub_matches).await?,
         ActionType::Exit | ActionType::Clear => {
             info!("Exit or Clear is not supported action for unix domain client")
         }
@@ -142,10 +142,12 @@ async fn handle_test(socket: UnixDatagram) -> HandleUdsResult {
     Ok(())
 }
 
-async fn handle_history(socket: UnixDatagram) -> HandleUdsResult {
+async fn handle_history(socket: UnixDatagram, sub_matches: &ArgMatches) -> HandleUdsResult {
+    let should_clear = sub_matches.get_flag("clear");
+
     socket
         .send(
-            UdsMessage::Public(MessageRequest::History)
+            UdsMessage::Public(MessageRequest::History { should_clear })
                 .encode()
                 .map_err(UdsHandlerError::EncodeFailed)?
                 .as_slice(),

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -64,7 +64,7 @@ pub enum MessageRequest {
     Delete { id: u16, all: bool },
     List { show_percentage: bool },
     Test,
-    History,
+    History { should_clear: bool },
 }
 
 impl Bincodec for MessageRequest {
@@ -105,8 +105,16 @@ impl From<MessageRequest> for UserInput {
                 }
             }
             MessageRequest::Test => String::from(ActionType::Test),
-            MessageRequest::History => String::from(ActionType::History),
+            MessageRequest::History { should_clear } => {
+                if should_clear {
+                    format!("{} --clear", String::from(ActionType::History))
+                } else {
+                    String::from(ActionType::History)
+                }
+            }
         };
+
+        debug!("input: {:?}", input);
 
         UserInput {
             input,


### PR DESCRIPTION
## Description
This PR resolved #180 . Now `history --clear` command is supported in ipc mode.