### PR TITLE
Update configuration reporting with work and break time

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -68,6 +68,8 @@ pub enum ConfigurationError {
     JsonError(SerdeJsonError),
     SlackConfigNotFound,
     DiscordConfigNotFound,
+    UnspecifiedWorkTime,
+    UnspecifiedBreakTime,
     LoadFail(io::Error),
     // config json wrong format?
 }
@@ -75,7 +77,7 @@ pub enum ConfigurationError {
 impl fmt::Display for ConfigurationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            ConfigurationError::FileNotFound => write!(f, "can not find configuration file "),
+            ConfigurationError::FileNotFound => write!(f, "can not find configuration file"),
             ConfigurationError::FileOpenError(_) => write!(f, "failed to open the file"),
             ConfigurationError::JsonError(_) => write!(f, "failed to deserialize json"),
             ConfigurationError::SlackConfigNotFound => {
@@ -84,6 +86,8 @@ impl fmt::Display for ConfigurationError {
             ConfigurationError::DiscordConfigNotFound => {
                 write!(f, "can not find discord config in json")
             }
+            ConfigurationError::UnspecifiedWorkTime => write!(f, "not specified"),
+            ConfigurationError::UnspecifiedBreakTime => write!(f, "not specified"),
             ConfigurationError::LoadFail(e) => write!(f, "failed to load: {}", e),
         }
     }
@@ -97,6 +101,8 @@ impl std::error::Error for ConfigurationError {
             ConfigurationError::JsonError(ref e) => Some(e),
             ConfigurationError::SlackConfigNotFound => None,
             ConfigurationError::DiscordConfigNotFound => None,
+            ConfigurationError::UnspecifiedWorkTime => None,
+            ConfigurationError::UnspecifiedBreakTime => None,
             ConfigurationError::LoadFail(ref e) => Some(e),
         }
     }

--- a/src/report.rs
+++ b/src/report.rs
@@ -68,7 +68,7 @@ pub fn generate_configuration_report(
             .update_reason(&ConfigurationError::UnspecifiedWorkTime),
     };
 
-    let break_time_default_value_message = match config.get_work_time() {
+    let break_time_default_value_message = match config.get_break_time() {
         Some(_) => Report::new("O", "default_break_time"),
         None => Report::new("X", "default_break_time")
             .update_reason(&ConfigurationError::UnspecifiedBreakTime),

--- a/src/report.rs
+++ b/src/report.rs
@@ -49,7 +49,7 @@ pub fn generate_configuration_report(
             .update_reason(&ConfigurationError::SlackConfigNotFound),
     };
 
-    let slack_token_message = match config.get_slack_channel() {
+    let slack_token_message = match config.get_slack_token() {
         Some(_) => Report::new("O", "slack_token"),
         None => {
             Report::new("X", "slack_token").update_reason(&ConfigurationError::SlackConfigNotFound)
@@ -62,11 +62,25 @@ pub fn generate_configuration_report(
             .update_reason(&ConfigurationError::DiscordConfigNotFound),
     };
 
+    let work_time_default_value_message = match config.get_work_time() {
+        Some(_) => Report::new("O", "default_work_time"),
+        None => Report::new("X", "default_work_time")
+            .update_reason(&ConfigurationError::UnspecifiedWorkTime),
+    };
+
+    let break_time_default_value_message = match config.get_work_time() {
+        Some(_) => Report::new("O", "default_break_time"),
+        None => Report::new("X", "default_break_time")
+            .update_reason(&ConfigurationError::UnspecifiedBreakTime),
+    };
+
     Table::new(vec![
         config_err_message,
         slack_channel_message,
         slack_token_message,
         discord_webhook_url_message,
+        work_time_default_value_message,
+        break_time_default_value_message,
     ])
     .with(Style::modern())
     .to_string()


### PR DESCRIPTION
- Added work and break time specifications on the configuration report
- `get_slack_channel` was being called twice instead of `get_slack_token` in the report. This was also fixed. Resolves #186.

https://github.com/24seconds/rust-cli-pomodoro/blob/16c06876e24875df462169595de50de43c136cae/src/report.rs#L46-L52