### PR TITLE
wait certain time when send data in mac os

### DIFF
--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -7,7 +7,7 @@ use std::fs;
 use std::path::PathBuf;
 use std::time::Duration;
 use tokio::net::UnixDatagram;
-use tokio::time::{timeout, sleep};
+use tokio::time::{sleep, timeout};
 
 use crate::command::action::ActionType;
 use crate::InputSource;
@@ -339,7 +339,7 @@ pub async fn send_to(socket: &UnixDatagram, target: PathBuf, buf: &[u8]) {
         debug!("buf length to be sent: {}", buf.len());
         socket.send_to(buf, &target).await.unwrap();
 
-        // Wait for certain time due to 
+        // Wait for certain time due to
         // "No buffer space available" error in mac os.
         #[cfg(target_os = "macos")]
         sleep(tokio::time::Duration::from_millis(1)).await;

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -7,7 +7,7 @@ use std::fs;
 use std::path::PathBuf;
 use std::time::Duration;
 use tokio::net::UnixDatagram;
-use tokio::time::timeout;
+use tokio::time::{timeout, sleep};
 
 use crate::command::action::ActionType;
 use crate::InputSource;
@@ -338,6 +338,11 @@ pub async fn send_to(socket: &UnixDatagram, target: PathBuf, buf: &[u8]) {
         let buf = &buf[start..end];
         debug!("buf length to be sent: {}", buf.len());
         socket.send_to(buf, &target).await.unwrap();
+
+        // Wait for certain time due to 
+        // "No buffer space available" error in mac os.
+        #[cfg(target_os = "macos")]
+        sleep(tokio::time::Duration::from_millis(1)).await;
     }
 
     let fin = Vec::new();


### PR DESCRIPTION
## Description
There is a bug in `rust-cli-pomodoro` in mac os. When the number of deleted notifications are large, calling command `history` in `ipc mode`  makes error.

### Bug reproduce
1. Prepare two terminal tabs, let say terminal A and terminal B.
2. Run `rust-cli-pomodoro` app in terminal A.
3. Run `pomodoro q -d` 20 times in terminal B.
4. Run `pomodoro history` in terminal B.
5. You will see the error message 
``` txt
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 55, kind: Uncategorized, message: "No buffer space available" }'
```

### Solution
According to the [stackoverflow](https://stackoverflow.com/questions/21973661/os-x-udp-send-error-55-no-buffer-space-available) about this error, it says
> On BSD systems sendto NEVER blocks, the docs are wrong. Mixed with some OSX specific problem when connected to high speed lans. Overall: Just don't think that sendto blocks, it doesn't on BSD. The good thing: If you know that, you can take this into account.

So I think maybe waiting for certain time can solve this problem and tried and it worked.
